### PR TITLE
fix: fix: can't find ./consts.zeek

### DIFF
--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -2,4 +2,5 @@ spicy_add_analyzer(
     NAME IPSEC
     PACKAGE_NAME IPSEC
     SOURCES analyzer.spicy analyzer.evt zeek_analyzer.spicy
-    SCRIPTS __load__.zeek main.zeek dpd.sig)
+    SCRIPTS __load__.zeek main.zeek dpd.sig consts.zeek
+)


### PR DESCRIPTION
got error

```
fatal error in /opt/spicy/lib/zeek-spicy/scripts/IPSEC/ipsec/__load__.zeek, line 2: can't find ./consts.zeek
```