### PR TITLE
fix call to try_register_packet_analyzer_by_name for newer Spicy

### DIFF
--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -690,10 +690,12 @@ event zeek_init() &priority=5
 
 event zeek_init()
 	{
-	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x32, "spicy::ipsec_esp") )
-		Reporter::error("cannot register IPSec Spicy analyzer");
-	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x33, "spicy::ipsec_ah") )
-		Reporter::error("cannot register IPSec Spicy analyzer");
+	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x32, "spicy_ipsec_esp") )
+		if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x32, "spicy::ipsec_esp") )
+			Reporter::error("cannot register IPSec Spicy analyzer");
+	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x33, "spicy_ipsec_ah") )
+		if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x33, "spicy::ipsec_ah") )
+			Reporter::error("cannot register IPSec Spicy analyzer");
 	}
 
 function set_session(c: connection)


### PR DESCRIPTION
change naming convention for try_register_packet_analyzer_by_name to use _ instead of :: which is what newer spicy wants.

Older versions of spicy accepted (expected?) something like `spicy::ipsec_esp`, but now it's `spicy_ipsec_esp`. I've adjusted these calls to try the newer format first, then fall back to try the original format before failing.

```
event zeek_init()
	{
	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x32, "spicy_ipsec_esp") )
		if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x32, "spicy::ipsec_esp") )
			Reporter::error("cannot register IPSec Spicy analyzer");
	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x33, "spicy_ipsec_ah") )
		if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x33, "spicy::ipsec_ah") )
			Reporter::error("cannot register IPSec Spicy analyzer");
	}
```